### PR TITLE
define get-scroll-bar-mode function if it is not available

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -404,6 +404,10 @@ install the memoized function over the original function."
          ""
        (propertize " " 'face plface)))))
 
+;; get-scroll-bar-mode is not available in emacs 23.2
+(if (not (functionp 'get-scroll-bar-mode))
+    (defun get-scroll-bar-mode () scroll-bar-mode))
+
 (defun powerline-make-fill
   (color)
   ;; justify right by filling with spaces to right fringe, 20 should be calculated


### PR DESCRIPTION
In emacs 23.2, I was getting a blank modeline, similar to the issue https://github.com/jonathanchu/emacs-powerline/issues/4. But the cause turned out to be different in my case.

It turns out that `get-scroll-bar-mode` was defined in the `scroll-bar.el` that came with emacs 24, but it wasn't available in 23.2.

The patch fixes emacs 23.2 for me. It is not tested in emacs 24.
