### PR TITLE
powerline.el has a requirement on cl

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -13,6 +13,8 @@
 
 ;;; Code:
 
+(require 'cl)
+
 (defvar powerline-color1)
 (defvar powerline-color2)
 


### PR DESCRIPTION
powerline.el requires "cl" in order to use the typecase function.
