### PR TITLE
Checks whether scroll-bar-mode is defined before calling it and fixes typo.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Additionally, you can modify directly in `powerline.el`:
     (setq powerline-color1 "grey22")
     (setq powerline-color2 "grey40")
 
-Change the :forebround, :background, powerline-color1, powerline-color2 to whatever you wish.
+Change the :foreground, :background, powerline-color1, powerline-color2 to whatever you wish.
 
 
 Screenshots

--- a/powerline.el
+++ b/powerline.el
@@ -25,7 +25,8 @@
 (set-face-attribute 'mode-line-inactive nil
                     :box nil)
 
-(scroll-bar-mode -1)
+(if (functionp 'scroll-bar-mode)
+    (scroll-bar-mode -1))
 
 (defun arrow-left-xpm
   (color1 color2)


### PR DESCRIPTION
Checks whether scroll-bar-mode is defined before calling it.

```
* The terminal version of Emacs 24.1.50.1 does not load
  scroll-bar-mode and hence throws an error when loading
  powerline. This patch only stops the error from appearing.
  However, the modeline becomes totally green and unusable
  in the terminal on Mac OS X. That needs fixing.
```

Fixes a typo in the readme.

Patch to project approved.
