### PR TITLE
Format `mode-name` with `format-mode-line`

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -474,7 +474,7 @@ install the memoized function over the original function."
                                                          (not powerline-buffer-size-suffix))
                                                    (redraw-modeline)))))
 (defpowerline rmw         "%*")
-(defpowerline major-mode  (propertize mode-name
+(defpowerline major-mode  (propertize (format-mode-line mode-name)
                                       'help-echo "Major mode\n\ mouse-1: Display major mode menu\n\ mouse-2: Show help for major mode\n\ mouse-3: Toggle minor modes"
                                       'local-map (let ((map (make-sparse-keymap)))
                                                    (define-key map [mode-line down-mouse-1]


### PR DESCRIPTION
Hi Jonathan — thanks for making this addon! It's made Emacs look so much sleeker :)

In the powerline major mode display, the mode name was being processed without checking its type. This failed for modes like html-mode, which store a list in `mode-name`.

I added a call to `format-mode-line` so that `mode-name` is processed and a string always passed to the modeline display.
