### PR TITLE
Arrow shape fixed in case of even modeline height

### DIFF
--- a/powerline.el
+++ b/powerline.el
@@ -32,16 +32,28 @@
 
 (defun get-arrow-dots
   (leftp width height)
-  (mapconcat
-   (apply-partially 'format "\"%s\"")
-   (mapcar
-    (lambda (n)
-       (let* ((nx (if (< n (/ height 2)) n (- height n)))
-              (dots (make-string nx ?.))
-              (spaces (make-string (- width nx) ? )))
-         (if leftp (concat dots spaces) (concat spaces dots))))
-    (number-sequence 1 height))
-   ",\n"))
+  (let* ((halfheight (/ height 2)))
+    (mapconcat
+     (apply-partially 'format "\"%s\"")
+     (mapcar
+      (lambda (n)
+	(let* ((nx (if (< n halfheight) n (- height n)))
+	       (dots (make-string nx ?.))
+	       (spaces (make-string (- width nx) ? )))
+	  (if leftp
+	      (concat dots spaces)
+	    (concat spaces dots))))
+      (arrow-number-sequence height))
+     ",\n")))
+
+(defun arrow-number-sequence
+  (height)
+  (if (oddp height)
+      (number-sequence 1 height)
+    (let* ((halfheight (/ height 2)))
+      (append
+       (number-sequence 1 halfheight)
+       (cons halfheight (number-sequence (1+ halfheight) (1- height)))))))
 
 (defun get-arrow-xpm
   (direction width height &optional color1 color2)


### PR DESCRIPTION
Hi!
I have found small issue in get-arrow-dots function.
The result of calling `(get-arrow-dots 'left 6 12)` was

```
\".     \",
\"..    \",
\"...   \",
\"....  \",
\"..... \",
\"......\",
\"..... \",
\"....  \",
\"...   \",
\"..    \",
\".     \",
\"      \"
```

The problem is that this arrow is asymmetrical and it wasn't pixel perfect when rendered in modeline - that looked a bit ugly to me.

But from now on,   `(get-arrow-dots 'left 6 12)`  generates the following:

```
\".     \",
\"..    \",
\"...   \",
\"....  \",
\"..... \",
\"......\",
\"......\",
\"..... \",
\"....  \",
\"...   \",
\"..    \",
\".     \"
```

Arrow is symmetrical now and looks perfectly.
Thank you.
